### PR TITLE
Add --conda flag. Add --key flag. Add --pdb flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ python:
 - 3.5
 - 3.6
 
+matrix:
+  allow_failures:
+  # currently stdlib-list is not py36 compatible
+  # https://github.com/jackmaney/python-stdlib-list
+  - python: 3.6
+
+
 install:
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - 2.7
 - 3.4
 - 3.5
+- 3.6
 
 install:
   - pip install -r requirements.txt

--- a/depfinder/cli.py
+++ b/depfinder/cli.py
@@ -177,7 +177,9 @@ def cli():
         if args.yaml:
             print(yaml.dump(deps, default_flow_style=False))
         elif args.conda:
-            print(' '.join(itertools.chain(deps.values())))
+            list_of_deps = [item for sublist in itertools.chain(deps.values())
+                            for item in sublist]
+            print(' '.join(list_of_deps))
         else:
             pprint(deps)
 

--- a/depfinder/cli.py
+++ b/depfinder/cli.py
@@ -33,8 +33,9 @@ from collections import defaultdict
 import logging
 import os
 from pprint import pprint
-from functools import partial
 import itertools
+import pdb
+import sys
 
 import yaml
 
@@ -110,6 +111,12 @@ Tool for inspecting the dependencies of your python project.
         help=("Format output so it can be passed as an argument to conda "
               "install or conda create")
     )
+    p.add_argument(
+        '--pdb',
+        action="store_true",
+        help="Enable PDB debugging on exception",
+        default=False,
+    )
     return p
 
 
@@ -120,6 +127,13 @@ def cli():
         msg = ("You have enabled both verbose mode (--verbose or -v) and "
                "quiet mode (-q or --quiet).  Please pick one. Exiting...")
         raise InvalidSelection(msg)
+
+    if args.pdb:
+        # set the pdb_hook as the except hook for all exceptions
+        def pdb_hook(exctype, value, traceback):
+            pdb.post_mortem(traceback)
+        sys.excepthook = pdb_hook
+
 
     # Configure Logging
     loglevel = logging.INFO

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,7 @@ import pytest
 
 if __name__ == '__main__':
     # show output results from every test function
-    args = ['-v', 'tests']
+    args = ['-v', 'test.py']
     # show the message output for skipped and expected failure tests
     args.append('-rxs')
     args.extend(sys.argv[1:])

--- a/test.py
+++ b/test.py
@@ -159,6 +159,7 @@ def test_notebook_remapping():
         assert {'required': ['mpl_toolkits']} == deps
         assert {} == main.notebook_path_to_dependencies(fname)
 
+
 @pytest.mark.parametrize("import_list_dict", [complex_imports,
                                               simple_imports,
                                               relative_imports])
@@ -252,6 +253,11 @@ def known_flags():
     flags = [flag for flag in flags if flag]
     # now flatten the nested list
     flags = [flag for flag_twins in flags for flag in flag_twins]
+    flags.remove('-k')
+    flags.remove('--key')
+    flags.remove('--pdb')
+    flags.extend(['-k all', '-k required', '-k optional', '-k builtin',
+                  '-k relative'])
     return flags
 
 


### PR DESCRIPTION
`--conda flag`. The conda flag formats all output as a space-delimited string so
that you can pass it to conda install or conda create. e.g., 

```bash
$ conda install $(depfinder /path/to/source --key required --conda)
```

`--key flag. (Also -k).` The key flag takes one of the four output types
(required, optional, relative, builtin) and only shows the output for that
import type.  Note that more than one --key can be passed. e.g., 

```bash
depfinder /path/to/source --key required --key optional
```

`--pdb flag`.  With the --pdb flag, the user is dropped in to the debugger to
help figure out what went wrong.