### PR TITLE
Test on py36 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ python:
 - 3.5
 - 3.6
 
-matrix:
-  allow_failures:
-  # currently stdlib-list is not py36 compatible
-  # https://github.com/jackmaney/python-stdlib-list
-  - python: 3.6
-
-
 install:
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt


### PR DESCRIPTION
stdlib-list is now py36 compatible: https://github.com/jackmaney/python-stdlib-list/issues/6