### PR TITLE
Support notebooks that contain IPython specific syntaxes like magics.

### DIFF
--- a/depfinder/main.py
+++ b/depfinder/main.py
@@ -350,11 +350,19 @@ def notebook_path_to_dependencies(path_to_notebook, remap=True):
     >>> depfinder.notebook_path_to_dependencies('depfinder_usage.ipynb')
     {'builtin': ['os', 'pprint'], 'required': ['depfinder']}
     """
+    try:
+        from IPython.core.inputsplitter import IPythonInputSplitter
+        transform = IPythonInputSplitter().transform_cell
+    except:
+        transform = lambda code: code
+
     nb = json.load(open(path_to_notebook))
     codeblocks = [''.join(cell['source']) for cell in nb['cells']
                   if cell['cell_type'] == 'code']
     all_deps = defaultdict(set)
+
     for codeblock in codeblocks:
+        codeblock = transform(codeblock)
         deps_dict = get_imported_libs(codeblock).describe()
         for k, v in deps_dict.items():
             all_deps[k].update(v)

--- a/depfinder/main.py
+++ b/depfinder/main.py
@@ -352,7 +352,7 @@ def notebook_path_to_dependencies(path_to_notebook, remap=True):
     """
     try:
         from IPython.core.inputsplitter import IPythonInputSplitter
-        transform = IPythonInputSplitter().transform_cell
+        transform = IPythonInputSplitter(line_input_checker=False).transform_cell
     except:
         transform = lambda code: code
 


### PR DESCRIPTION
`depfinder` seems to get mad when notebooks have IPython specific commands like `!`, `%`, or `%%`.  This pull request adds IPython's cell transformation to the notebook dependency function.