### PR TITLE
add beautifulsoup4 to _PACKAGE_MAPPING

### DIFF
--- a/depfinder/main.py
+++ b/depfinder/main.py
@@ -90,7 +90,7 @@ class ImportFinder(ast.NodeVisitor):
         """Recursively visit all ast nodes.
 
         Look for Import and ImportFrom nodes. Classify them as being imports
-        that are built in, relative, required or questionable. Qustionable
+        that are built in, relative, required or questionable. Questionable
         imports are those that occur within the context of a try/except block, a
         function definition or a class definition.
 
@@ -376,6 +376,7 @@ PACKAGE_NAME = None
 
 _PACKAGE_MAPPING = {
     'av': 'pyav',
+    'bs4': 'beautifulsoup4',
     'cv2': 'opencv',
     'IPython': 'ipython',
     'netCDF4': 'netcdf4',


### PR DESCRIPTION
@ericdill and @tonyfast any advice on how to deal with named spaced packages like `ruamel.yaml`? `depfinder` will use the import name `ruamel` but there is no such package. However, the `ruamel.yaml.__package__` info is correct. I wonder if we could take advantage of that instead and produce a more accurate result.