### PR TITLE
Continue parsing even if we encounter a file parsing error

### DIFF
--- a/depfinder/cli.py
+++ b/depfinder/cli.py
@@ -39,6 +39,7 @@ import sys
 
 import yaml
 
+from . import main
 from .main import (simple_import_search, notebook_path_to_dependencies,
                    parse_file, sanitize_deps)
 
@@ -122,6 +123,12 @@ Tool for inspecting the dependencies of your python project.
         default=None,
         help="Blacklist pattern for files not to inpsect"
     )
+    p.add_argument(
+        '--strict',
+        default=False,
+        action="store_true",
+        help=("Immediately raise an Exception if any files fail to parse. Defaults to off.")
+    )
     return p
 
 
@@ -139,6 +146,7 @@ def cli():
             pdb.post_mortem(traceback)
         sys.excepthook = pdb_hook
 
+    main.STRICT_CHECKING = args.strict
 
     # Configure Logging
     loglevel = logging.INFO
@@ -165,7 +173,7 @@ def cli():
     keys = args.key
     if keys == []:
         keys = None
-    logging.debug('keys', keys)
+    logger.debug('keys: %s', keys)
 
     def dump_deps(deps, keys):
         """

--- a/depfinder/main.py
+++ b/depfinder/main.py
@@ -288,11 +288,20 @@ def iterate_over_library(path_to_source_code):
         PACKAGE_NAME = os.path.basename(path_to_source_code).split('.')[0]
         logger.debug("Setting PACKAGE_NAME global variable to {}"
                      "".format(PACKAGE_NAME))
+    skipped_files = []
     for parent, folders, files in os.walk(path_to_source_code):
         for f in files:
             if f.endswith('.py'):
                 full_file_path = os.path.join(parent, f)
-                yield parse_file(full_file_path)
+                try:
+                    yield parse_file(full_file_path)
+                except Exception:
+                    logger.exception("Could not parse file: {}".format(full_file_path))
+                    skipped_files.append(full_file_path)
+    if skipped_files:
+        logger.warning("Skipped {} files".format(len(skipped_files)))
+        for idx, f in enumerate(skipped_files):
+            logger.warn("%s: %s" % (str(idx), f))
 
 
 def simple_import_search(path_to_source_code, remap=True, blacklist=None):

--- a/depfinder/main.py
+++ b/depfinder/main.py
@@ -289,17 +289,19 @@ def iterate_over_library(path_to_source_code):
         logger.debug("Setting PACKAGE_NAME global variable to {}"
                      "".format(PACKAGE_NAME))
     skipped_files = []
+    all_files = []
     for parent, folders, files in os.walk(path_to_source_code):
         for f in files:
             if f.endswith('.py'):
                 full_file_path = os.path.join(parent, f)
+                all_files.append(full_file_path)
                 try:
                     yield parse_file(full_file_path)
                 except Exception:
                     logger.exception("Could not parse file: {}".format(full_file_path))
                     skipped_files.append(full_file_path)
     if skipped_files:
-        logger.warning("Skipped {} files".format(len(skipped_files)))
+        logger.warning("Skipped {}/{} files".format(len(skipped_files), len(all_files)))
         for idx, f in enumerate(skipped_files):
             logger.warn("%s: %s" % (str(idx), f))
 


### PR DESCRIPTION
Ran into a codebase at work today that has some files that still contain print statements, but the bulk of the code is >py36 with f-strings. Best solution I could come up with is just to skip the files that have parsing errors and log that we skipped some files.

Thoughts @ocefpaf @CJ-Wright @tonyfast ?