### PR TITLE
ENH support custom namespaces

### DIFF
--- a/depfinder/cli.py
+++ b/depfinder/cli.py
@@ -43,6 +43,7 @@ from . import main
 from .inspection import parse_file
 from .main import (simple_import_search, notebook_path_to_dependencies,
                    sanitize_deps)
+from .utils import custom_namespaces
 
 logger = logging.getLogger('depfinder')
 
@@ -130,6 +131,16 @@ Tool for inspecting the dependencies of your python project.
         action="store_true",
         help=("Immediately raise an Exception if any files fail to parse. Defaults to off.")
     )
+    p.add_argument(
+        '--custom-namespaces',
+        default='',
+        help=(
+            "A comma-separated list of custom namespace packages. "
+            "Listing namespaces here will enable depfinder to properly report "
+            "dependencies when a namespace is in use (e.g., depfinder will report "
+            "both foo.bar and foo.baz instead of foo when run with --custom-namespaces=foo)."
+        )
+    )
     return p
 
 
@@ -146,6 +157,11 @@ def cli():
         def pdb_hook(exctype, value, traceback):
             pdb.post_mortem(traceback)
         sys.excepthook = pdb_hook
+
+    global custom_namespaces
+    cs = args.custom_namespaces.split(",")
+    if len(cs) > 0:
+        custom_namespaces.extend(cs)
 
     main.STRICT_CHECKING = args.strict
 

--- a/depfinder/inspection.py
+++ b/depfinder/inspection.py
@@ -38,7 +38,10 @@ from typing import Union
 
 from stdlib_list import stdlib_list
 
-from .utils import AST_QUESTIONABLE, namespace_packages, SKETCHY_TYPES_TABLE
+from .utils import (
+    AST_QUESTIONABLE, namespace_packages, SKETCHY_TYPES_TABLE,
+    custom_namespaces
+)
 
 logger = logging.getLogger('depfinder')
 
@@ -52,7 +55,16 @@ STRICT_CHECKING = False
 
 
 def get_top_level_import_name(name):
+    num_dot = name.count(".")
+
     if name in namespace_packages:
+        return name
+    elif any(
+        ((num_dot - nsp.count(".")) == 1) and name.startswith(nsp + ".")
+        for nsp in custom_namespaces
+    ):
+        # this branch happens when name is foo.bar.baz and the namespace is
+        # foo.bar
         return name
     else:
         if '.' not in name:

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -61,7 +61,3 @@ else:
     )
 
 namespace_packages = {pkg['import_name'] for pkg in mapping_list if '.' in pkg['import_name']}
-
-# this global holds custom namespaces for namespace packages (e.g., a set of
-# packages like foo.bar and foo.baz where foo itself is not a package)
-custom_namespaces = []

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -61,3 +61,7 @@ else:
     )
 
 namespace_packages = {pkg['import_name'] for pkg in mapping_list if '.' in pkg['import_name']}
+
+# this global holds custom namespaces for namespace packages (e.g., a set of
+# packages like foo.bar and foo.baz where foo itself is not a package)
+custom_namespaces = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ versionfile_source = depfinder/_version.py
 versionfile_build = depfinder/_version.py
 tag_prefix = v
 #parentdir_prefix =
+
+[flake8]
+max-line-length=300

--- a/test.py
+++ b/test.py
@@ -271,6 +271,7 @@ def known_flags():
     flags.remove('--key')
     flags.remove('--pdb')
     flags.remove('--ignore')
+    flags.remove('--custom-namespaces')
     flags.extend(['-k all', '-k required', '-k optional', '-k builtin',
                   '-k relative'])
     return flags


### PR DESCRIPTION
This PR adds support for custom namespaces. 

Before

```
$ depfinder metadetect
{'builtin': ['__future__',
             'contextlib',
             'copy',
             'logging',
             'os',
             'pdb',
             'sys',
             'time',
             'warnings'],
 'questionable': ['astropy',
                  'biggles',
                  'descwl_coadd',
                  'images',
                  'lsst',
                  'matplotlib',
                  'scarlet',
                  'sxdes'],
 'relative': ['_version',
              'configs',
              'defaults',
              'detect',
              'fitting',
              'interpolate',
              'masking',
              'measure',
              'metacal_exposures',
              'mfrac',
              'procflags',
              'sim',
              'skysub',
              'util'],
 'required': ['descwl_coadd',
              'descwl_shear_sims',
              'esutil',
              'galsim',
              'lsst',
              'matplotlib',
              'meds',
              'ngmix',
              'numba',
              'numpy',
              'pytest',
              'scipy',
              'tqdm']}
```

and after

```
$ depfinder --custom-namespaces=lsst metadetect
{'builtin': ['__future__',
             'contextlib',
             'copy',
             'logging',
             'os',
             'pdb',
             'sys',
             'time',
             'warnings'],
 'questionable': ['astropy',
                  'biggles',
                  'descwl_coadd',
                  'images',
                  'lsst.afw',
                  'lsst.geom',
                  'lsst.meas',
                  'lsst.pex',
                  'lsst.pipe',
                  'matplotlib',
                  'scarlet',
                  'sxdes'],
 'relative': ['_version',
              'configs',
              'defaults',
              'detect',
              'fitting',
              'interpolate',
              'masking',
              'measure',
              'metacal_exposures',
              'mfrac',
              'procflags',
              'sim',
              'skysub',
              'util'],
 'required': ['descwl_coadd',
              'descwl_shear_sims',
              'esutil',
              'galsim',
              'lsst.afw',
              'lsst.geom',
              'lsst.meas',
              'lsst.pex',
              'matplotlib',
              'meds',
              'ngmix',
              'numba',
              'numpy',
              'pytest',
              'scipy',
              'tqdm']}
```