### PR TITLE
ENH enable using upstream number of letters

### DIFF
--- a/depfinder/reports.py
+++ b/depfinder/reports.py
@@ -49,10 +49,19 @@ del pyver
 
 
 @lru_cache()
-def _import_map_cache(import_first_two_letters):
+def _import_map_num_letters():
+    req = requests.get(
+        'https://raw.githubusercontent.com/regro/libcfgraph/master'
+        'import_maps_meta.json')
+    req.raise_for_status()
+    return int(req.json()['num_letters'])
+
+
+@lru_cache()
+def _import_map_cache(import_first_letters):
     req = requests.get(
         f'https://raw.githubusercontent.com/regro/libcfgraph'
-        f'/master/import_maps/{import_first_two_letters.lower()}.json')
+        f'/master/import_maps/{import_first_letters.lower()}.json')
     if not req.ok:
         print('Request to {req_url} failed'.format(req_url=req.url))
         return {}
@@ -79,8 +88,9 @@ def extract_pkg_from_import(name):
     -------
 
     """
-    ftl = name[:2]
-    import_map = _import_map_cache(ftl)
+    num_letters = _import_map_num_letters()
+    fllt = name[:min(len(name), num_letters)]
+    import_map = _import_map_cache(fllt)
     original_name = name
     while True:
         try:

--- a/depfinder/reports.py
+++ b/depfinder/reports.py
@@ -89,11 +89,11 @@ def extract_pkg_from_import(name):
 
     """
     num_letters = _import_map_num_letters()
-    fllt = name[:min(len(name), num_letters)]
-    import_map = _import_map_cache(fllt)
     original_name = name
     while True:
         try:
+            fllt = name[:min(len(name), num_letters)]
+            import_map = _import_map_cache(fllt)
             supplying_artifacts = import_map[name]
         except KeyError:
             if '.' not in name:

--- a/depfinder/reports.py
+++ b/depfinder/reports.py
@@ -52,7 +52,7 @@ del pyver
 def _import_map_num_letters():
     req = requests.get(
         'https://raw.githubusercontent.com/regro/libcfgraph/master'
-        'import_maps_meta.json')
+        '/import_maps_meta.json')
     req.raise_for_status()
     return int(req.json()['num_letters'])
 

--- a/news/new_news.rst
+++ b/news/new_news.rst
@@ -4,4 +4,4 @@
 
 **Changed:**
 
-* Changed handling of import maps to compute number of letters from upstream data.
+* Changed handling of import maps to compute number of letters from upstream data. 

--- a/news/new_news.rst
+++ b/news/new_news.rst
@@ -5,19 +5,3 @@
 **Changed:**
 
 * Changed handling of import maps to compute number of letters from upstream data.
-
-**Deprecated:**
-
-* <news item>
-
-**Removed:**
-
-* <news item>
-
-**Fixed:**
-
-* <news item>
-
-**Security:**
-
-* <news item>

--- a/news/new_news.rst
+++ b/news/new_news.rst
@@ -4,4 +4,4 @@
 
 **Changed:**
 
-* Changed handling of import maps to compute number of letters from upstream data. 
+* Changed handling of import maps to compute number of letters from upstream data.

--- a/news/new_news.rst
+++ b/news/new_news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``--custom-namespaces`` option for custom name space searching.
+
+**Changed:**
+
+* Changed handling of import maps to compute number of letters from upstream data.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This PR changes the import map handling to grab the indexing number of letters from lincfgraph. I also added news from my previous PR and this one.