### PR TITLE
Fix --version flag

### DIFF
--- a/depfinder/cli.py
+++ b/depfinder/cli.py
@@ -58,10 +58,14 @@ Tool for inspecting the dependencies of your python project.
 """,
     )
     p.add_argument(
-        'file_or_directory',
-        help=("Valid options are a single python file, a single jupyter "
-              "(ipython) notebook or a directory of files that include "
-              "python files")
+        "file_or_directory",
+        help=(
+            "Valid options are a single python file, a single jupyter "
+            "(ipython) notebook or a directory of files that include "
+            "python files"
+        ),
+        # default=".",
+        nargs="?",
     )
     p.add_argument(
         '-y',
@@ -171,6 +175,10 @@ def cli():
         return 0
 
     file_or_dir = args.file_or_directory
+    logger.debug("file_or_dir: %s", file_or_dir)
+    if file_or_dir is None:
+        logger.warning("positional argument `file_or_directory` not provided.")
+        raise RuntimeError("positional argument `file_or_directory` is required")
     keys = args.key
     if keys == []:
         keys = None


### PR DESCRIPTION
Closes #70 . This maintains the current behavior. 

An alternative I considered when adding this was to make the positional argument _not_ required and instead just default it to ".", i.e., the current directory. What do you think about that @ocefpaf @beckermr ?