### PR TITLE
Fixup namespace resolution for builtins

### DIFF
--- a/depfinder/inspection.py
+++ b/depfinder/inspection.py
@@ -59,7 +59,7 @@ def get_top_level_import_name(name, custom_namespaces=None):
     num_dot = name.count(".")
     custom_namespaces = custom_namespaces or []
 
-    if name in namespace_packages:
+    if name in namespace_packages or name in custom_namespaces or name in stdlib_list():
         return name
     elif any(
         ((num_dot - nsp.count(".")) == 1) and name.startswith(nsp + ".")

--- a/test.py
+++ b/test.py
@@ -105,6 +105,9 @@ simple_imports = [
     # Hit the fake packages code block in main.sanitize_deps()
     {'targets': {'required': ['numpy']},
      'code': 'from numpy import warnings as npwarn'},
+    # Test for nested namespace resolution in stdlib builtins
+    {'targets': {'builtin': ['concurrent.futures']},
+     'code': 'import concurrent.futures'},
 ]
 
 relative_imports = [


### PR DESCRIPTION
previously, builtins like concurrent.futures would resolve as concurrent, not concurrent.futures. This PR fixes that so the resolution looks like

`builtin: ['concurrent.futures']`

whereas previously it would look like

`required: ['concurrent']`