### PR TITLE
Only even try to import stdlib-list if we're less than py39

### DIFF
--- a/depfinder/stdliblist.py
+++ b/depfinder/stdliblist.py
@@ -1,11 +1,16 @@
 import sys
+import logging
 
+logger = logging.getLogger('depfinder')
 
-try:
-    from stdlib_list import stdlib_list
-    pyver = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
-    builtin_modules = stdlib_list(pyver)
-    del pyver
-except ImportError:
-    # assuming py>=3.10
+if sys.version_info.major >= 10:
     builtin_modules = list(set(list(sys.stdlib_module_names) + list(sys.builtin_module_names)))
+else:
+    try:
+        from stdlib_list import stdlib_list
+        pyver = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
+        builtin_modules = stdlib_list(pyver)
+        del pyver
+    except ImportError:
+        logger.exception('stdlib-list required for python <= 3.9')
+        raise

--- a/depfinder/stdliblist.py
+++ b/depfinder/stdliblist.py
@@ -2,13 +2,14 @@ import sys
 import logging
 
 logger = logging.getLogger('depfinder')
+MAJOR, MINOR = sys.version_info.major, sys.version_info.minor
 
-if sys.version_info.major >= 10:
+if MAJOR == 3 and MINOR >= 10:
     builtin_modules = list(set(list(sys.stdlib_module_names) + list(sys.builtin_module_names)))
 else:
     try:
         from stdlib_list import stdlib_list
-        pyver = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
+        pyver = '%s.%s' % (MAJOR, MINOR)
         builtin_modules = stdlib_list(pyver)
         del pyver
     except ImportError:


### PR DESCRIPTION
@mariusvniekerk ran into an issue where stdlib-list was in the environment but python was >=3.10. so he was getting the stdlib-list import attempt even though we use a different code path for 3.10. this PR fixes that by making the version checking stricter.