### PR TITLE
Remove ClassDef from sketchy ast nodes & add missing ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![image](https://github.com/ericdill/depfinder/actions/workflows/tests.yml/badge.svg)](https://github.com/ericdill/depfinder/actions/workflows/tests.yml)
 
-[![image](http://codecov.io/github/ericdill/depfinder/coverage.svg?branch=main)](http://codecov.io/github/ericdill/depfinder?branch=main)
+[![image](http://codecov.io/github/ericdill/depfinder/coverage.svg?branch=main)](https://app.codecov.io/github/ericdill/depfinder?branch=main)
 
 -   [docs](https://ericdill.github.io/depfinder)
 -   [github repo](https://github.com/ericdill/depfinder)

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -26,10 +26,14 @@ except AttributeError:
 # 1. inside a try/except block
 # 2. inside a function (async or otherwise)
 # 3. part of an if/elif/else
+# 4. inside a loop
 AST_QUESTIONABLE = tuple(AST_TRY + [
     ast.FunctionDef,
     ast.AsyncFunctionDef,
     ast.If,
+    ast.While,
+    ast.For,
+    ast.AsyncFor,
 ])
 SKETCHY_TYPES_TABLE[ast.FunctionDef] = 'function'
 SKETCHY_TYPES_TABLE[ast.AsyncFunctionDef] = 'async-function'

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -25,6 +25,7 @@ except AttributeError:
 # this AST_QUESTIONABLE list comprises the various ways an import can be weird
 # 1. inside a try/except block
 # 2. inside a function
+# 3. part of an if/elif/else
 AST_QUESTIONABLE = tuple(AST_TRY + [ast.FunctionDef, ast.If])
 SKETCHY_TYPES_TABLE[ast.FunctionDef] = 'function'
 SKETCHY_TYPES_TABLE[ast.If] = 'if'

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -24,10 +24,15 @@ except AttributeError:
 
 # this AST_QUESTIONABLE list comprises the various ways an import can be weird
 # 1. inside a try/except block
-# 2. inside a function
+# 2. inside a function (async or otherwise)
 # 3. part of an if/elif/else
-AST_QUESTIONABLE = tuple(AST_TRY + [ast.FunctionDef, ast.If])
+AST_QUESTIONABLE = tuple(AST_TRY + [
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.If,
+])
 SKETCHY_TYPES_TABLE[ast.FunctionDef] = 'function'
+SKETCHY_TYPES_TABLE[ast.AsyncFunctionDef] = 'async-function'
 SKETCHY_TYPES_TABLE[ast.If] = 'if'
 del AST_TRY
 

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -25,10 +25,8 @@ except AttributeError:
 # this AST_QUESTIONABLE list comprises the various ways an import can be weird
 # 1. inside a try/except block
 # 2. inside a function
-# 3. inside a class
-AST_QUESTIONABLE = tuple(AST_TRY + [ast.FunctionDef, ast.ClassDef, ast.If])
+AST_QUESTIONABLE = tuple(AST_TRY + [ast.FunctionDef, ast.If])
 SKETCHY_TYPES_TABLE[ast.FunctionDef] = 'function'
-SKETCHY_TYPES_TABLE[ast.ClassDef] = 'class'
 SKETCHY_TYPES_TABLE[ast.If] = 'if'
 del AST_TRY
 

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -22,12 +22,23 @@ except AttributeError:
     SKETCHY_TYPES_TABLE[ast.TryExcept] = 'try'
     SKETCHY_TYPES_TABLE[ast.TryFinally] = 'try'
 
+
+try:
+    # python 3.10+
+    AST_MATCH = [ast.match_case]
+    SKETCHY_TYPES_TABLE[ast.match_case] = 'match'
+except AttributeError:
+    # match/case does not exist before 3.10
+    AST_MATCH = []
+
+
 # this AST_QUESTIONABLE list comprises the various ways an import can be weird
 # 1. inside a try/except block
 # 2. inside a function (async or otherwise)
 # 3. part of an if/elif/else
 # 4. inside a loop
-AST_QUESTIONABLE = tuple(AST_TRY + [
+# 5. (for Python 3.10+) inside a match/case
+AST_QUESTIONABLE = tuple(AST_TRY + AST_MATCH + [
     ast.FunctionDef,
     ast.AsyncFunctionDef,
     ast.If,
@@ -38,7 +49,11 @@ AST_QUESTIONABLE = tuple(AST_TRY + [
 SKETCHY_TYPES_TABLE[ast.FunctionDef] = 'function'
 SKETCHY_TYPES_TABLE[ast.AsyncFunctionDef] = 'async-function'
 SKETCHY_TYPES_TABLE[ast.If] = 'if'
+SKETCHY_TYPES_TABLE[ast.While] = 'while'
+SKETCHY_TYPES_TABLE[ast.For] = 'for'
+SKETCHY_TYPES_TABLE[ast.AsyncFor] = 'async-for'
 del AST_TRY
+del AST_MATCH
 
 try:
     # Try and use the C extensions because they're faster

--- a/test.py
+++ b/test.py
@@ -50,19 +50,37 @@ try:
     import os
 except ImportError:
     # why would you put this in a try block??
-    pass"""},
-    {'targets': {'required': ['toplevel', 'toplevelfrom', 'inside_class', 'inside_class_from'],
-                 'questionable': ['function_inside_class',
-                                  'function_inside_class_from',
-                                  'inside_class',
-                                  'inside_class_from',
-                                  'inside_function',
-                                  'inside_function_from'],
-                 'relative': ['relative_function',
-                              'relative_function_inside_class',
-                              'relative_inside_class'],
-                 'builtin': ['os', 'pprint']},
-     'code': """
+        pass""",
+    },
+    {
+        "targets": {
+            "required": [
+                "toplevel",
+                "toplevelfrom",
+                "inside_class",
+                "inside_class_from",
+            ],
+            "questionable": [
+                "function_inside_class",
+                "function_inside_class_from",
+                "inside_for",
+                "inside_for_else",
+                "inside_function",
+                "inside_function_from",
+                "inside_async_function",
+                "inside_if",
+                "inside_else",
+                "inside_while",
+                "inside_nested_class",
+            ],
+            "relative": [
+                "relative_function",
+                "relative_function_inside_class",
+                "relative_inside_class",
+            ],
+            "builtin": ["os", "pprint"],
+        },
+        "code": """
 from toplevelfrom import some_function
 import toplevel
 def function():
@@ -79,11 +97,36 @@ class Class:
         from function_inside_class_from import some_function
         from .relative_function_inside_class import a_third_function
         import pprint
-"""},
 
-    {'targets':
-         {'questionable': ['chico', 'groucho', 'harpo']},
-     'code': """
+# Handle nesting properly. import in a class def should be treated as "required to import",
+# unless its inside any of the nodes that would render it questionable. This import _should_
+# land in the questionable section, so we want to make sure it does.
+if True:
+    class NestedClass:
+        import inside_nested_class
+# weird edge cases that we want to make sure end up sorted properly. This hits the "ast.While"
+for i in []:
+    import inside_for
+else:
+    import inside_for_else
+# import inside an async function. This hits the "ast.AsyncFunctionDef"
+async def async_function():
+    import inside_async_function
+# import inside an if block. This hits the "ast.If"
+foo = 'cat'
+if foo == 'cat':
+    import inside_if
+else:
+    import inside_else
+# import inside an if block. This hits the "ast.While"
+while True:
+    import inside_while
+    break
+""",
+    },
+    {
+        "targets": {"questionable": ["chico", "groucho", "harpo"]},
+        "code": """
 if this:
     import groucho
 elif that:

--- a/test.py
+++ b/test.py
@@ -51,7 +51,7 @@ try:
 except ImportError:
     # why would you put this in a try block??
     pass"""},
-    {'targets': {'required': ['toplevel', 'toplevelfrom'],
+    {'targets': {'required': ['toplevel', 'toplevelfrom', 'inside_class', 'inside_class_from'],
                  'questionable': ['function_inside_class',
                                   'function_inside_class_from',
                                   'inside_class',
@@ -205,11 +205,11 @@ def tester(import_list_dict, capsys):
         target = import_dict['targets']
         with write_notebook(cell_code) as fname:
             # parse the notebook!
-            assert target == main.notebook_path_to_dependencies(fname)
+            assert set(target) == set(main.notebook_path_to_dependencies(fname))
             # check the notebook cli
             _run_cli(path_to_check=fname)
             stdout, stderr = capsys.readouterr()
-            assert target == eval(stdout)
+            assert set(target) == set(eval(stdout))
 
 
 def test_multiple_code_cells(capsys):


### PR DESCRIPTION
See discussion in #84.

The code is completely speculative and I haven't tested it yet. I'm new here :). Specifically I haven't yet figured out the purpose of `SKETCHY_TYPES_TABLE`, and whether the literals I've put in are correct.

For the missing nodes:
- `async def` is the same as `def` for our purpose.
- Loops are all conditional; `while` is just an `if` made into a loop, `for` and `async for` execute only when the iterator is not empty.
- `match..case` is conditional. Looks like there's actually one node type we want to look for - `ast.match_case`.

Nothing has been tested yet, because it's well past midnight here :wink: proceed with caution.