### PR TITLE
ENH remove use of deprecated conda_forge_metadata APIs

### DIFF
--- a/depfinder/reports.py
+++ b/depfinder/reports.py
@@ -58,9 +58,9 @@ def extract_pkg_from_import(name):
         A dict mapping the import name to a set of possible packages that supply that import.
     """
     from conda_forge_metadata.autotick_bot import map_import_to_package
-    from conda_forge_metadata.libcfgraph import get_libcfgraph_pkgs_for_import
+    from conda_forge_metadata.autotick_bot import get_pkgs_for_import
     try:
-        supplying_pkgs, _ = get_libcfgraph_pkgs_for_import(name)
+        supplying_pkgs, _ = get_pkgs_for_import(name)
         best_import = map_import_to_package(name)
     except Exception:
         logger.exception(

--- a/news/cfmd.rst
+++ b/news/cfmd.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Removed usage of deprecated ``conda_forge_metadata.libcfgraph`` APIs.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ console_scripts =
 
 [options.extras_require]
 conda-forge =
-    conda-forge-metadata>=0.3.0
+    conda-forge-metadata>=0.7.0
 
 [flake8]
 max-line-length=300


### PR DESCRIPTION
This PR removes the use of deprecated libcfgraph metadata.