### PR TITLE
feat: allow newer versions of conda-forge-metadata

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Mamba
       uses: mamba-org/setup-micromamba@v3
       with:
-        environment-file: false
+        environment-name: base-test
 
     - name: Build environment
       run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Mamba
-      uses: mamba-org/provision-with-micromamba@v16
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
-         environment-file: false
+         environment-name: base-test
 
       - name: Python ${{ matrix.python-version }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 
@@ -43,7 +43,7 @@ jobs:
           && coverage run -m pytest -vrsx test.py
 
       - name: test w/ conda-forge-metadata
-        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
+        if: matrix.python-version != '3.9'
         run: >
           python -m pip install -e .[conda-forge] --force-reinstall
           && coverage run -m pytest -vrsx test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v3
         with:
          environment-file: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
           && coverage run -m pytest -vrsx test.py
 
       - name: test w/ conda-forge-metadata
+        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
         run: >
           python -m pip install -e .[conda-forge] --force-reinstall
           && coverage run -m pytest -vrsx test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -19,11 +23,6 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Set up Python

--- a/depfinder/reports.py
+++ b/depfinder/reports.py
@@ -57,8 +57,13 @@ def extract_pkg_from_import(name):
     import_to_pkg : dict mapping str to sets
         A dict mapping the import name to a set of possible packages that supply that import.
     """
-    from conda_forge_metadata.autotick_bot import map_import_to_package
-    from conda_forge_metadata.autotick_bot import get_pkgs_for_import
+    try:
+        from conda_forge_metadata.autotick_bot import map_import_to_package
+        from conda_forge_metadata.autotick_bot import get_pkgs_for_import
+    except ImportError:
+        from conda_forge_metadata.conda_forge_bot import map_import_to_package
+        from conda_forge_metadata.conda_forge_bot import get_pkgs_for_import
+
     try:
         supplying_pkgs, _ = get_pkgs_for_import(name)
         best_import = map_import_to_package(name)

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -90,6 +90,6 @@ except (ModuleNotFoundError, ImportError, AttributeError, requests.exceptions.HT
     mapping_list = yaml.load(
         pkgutil.get_data(__name__, 'pkg_data/name_mapping.yml').decode(),
         Loader=yaml_loader,
-)
+    )
 
 namespace_packages = {pkg['import_name'] for pkg in mapping_list if '.' in pkg['import_name']}

--- a/depfinder/utils.py
+++ b/depfinder/utils.py
@@ -71,8 +71,19 @@ pkg_data = yaml.load(
 )
 
 try:
-    import conda_forge_metadata.autotick_bot
-    mapping_list = conda_forge_metadata.autotick_bot.get_pypi_name_mapping()
+    import conda_forge_metadata.autotick_bot as conda_forge_bot
+except ImportError:
+    try:
+        import conda_forge_metadata.conda_forge_bot as conda_forge_bot
+    except ImportError:
+        conda_forge_bot = None
+
+
+try:
+    if conda_forge_bot is not None:
+        mapping_list = conda_forge_bot.get_pypi_name_mapping()
+    else:
+        raise ImportError("Could not import conda_forge_bot from conda_forge_metadata.")
 except (ImportError, AttributeError, requests.exceptions.HTTPError):
     logger.exception(
         "could not get the conda-forge metadata pypi-to-conda name mapping "
@@ -81,6 +92,6 @@ except (ImportError, AttributeError, requests.exceptions.HTTPError):
     mapping_list = yaml.load(
         pkgutil.get_data(__name__, 'pkg_data/name_mapping.yml').decode(),
         Loader=yaml_loader,
-    )
+)
 
 namespace_packages = {pkg['import_name'] for pkg in mapping_list if '.' in pkg['import_name']}

--- a/news/cfmd-again.rst
+++ b/news/cfmd-again.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed imports of ``conda_forge_metadata.autotick_bot`` to match new location at
+  ``conda_forge_metadata.conda_forge_bot``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     stdlib-list; python_version < "3.10"
     requests
 
-python_requires = >=3.8
+python_requires = >=3.9
 packages = find:
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     stdlib-list; python_version < "3.10"
     requests
 
-python_requires = >=2.7
+python_requires = >=3.10
 packages = find:
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ console_scripts =
 
 [options.extras_require]
 conda-forge =
-    conda-forge-metadata>=0.7.0
+    conda-forge-metadata>=0.14.0
 
 [flake8]
 max-line-length=300

--- a/test.py
+++ b/test.py
@@ -554,4 +554,9 @@ def test_simple_import_to_pkg_map():
         },
         'required no match': {}
     }
+    try:
+        import conda_forge_metadata.autotick_bot  # noqa: F401
+    except ImportError:
+        expected_result["questionable"]['conda_forge_metadata.conda_forge_bot'] = expected_result["questionable"]['conda_forge_metadata.autotick_bot']
+        del expected_result["questionable"]['conda_forge_metadata.autotick_bot']
     assert import_to_artifact == expected_result

--- a/test.py
+++ b/test.py
@@ -557,9 +557,4 @@ def test_simple_import_to_pkg_map():
         },
         'required no match': {}
     }
-    try:
-        import conda_forge_metadata.autotick_bot  # noqa: F401
-    except ImportError:
-        expected_result["questionable"]['conda_forge_metadata.conda_forge_bot'] = expected_result["questionable"]['conda_forge_metadata.autotick_bot']
-        del expected_result["questionable"]['conda_forge_metadata.autotick_bot']
     assert import_to_artifact == expected_result

--- a/test.py
+++ b/test.py
@@ -450,9 +450,18 @@ def test_get_top_level_import():
     top_level_name = inspection.get_top_level_import_name(name)
     assert top_level_name == 'this'
 
-    name = 'google.cloud.storage.something'
-    top_level_name = inspection.get_top_level_import_name(name)
-    assert top_level_name == 'google.cloud.storage'
+    from depfinder.utils import namespace_packages
+
+    if len(namespace_packages) > 0:
+        ns = sorted(namespace_packages)[0]
+        name = ns + '.something'
+        top_level_name = inspection.get_top_level_import_name(name)
+        assert top_level_name == ns
+
+    ns = ["my_custom_ns.ns"]
+    name = ns[0] + '.something'
+    top_level_name = inspection.get_top_level_import_name(name, custom_namespaces=ns)
+    assert top_level_name == ns[0]
 
 
 @pytest.mark.skipif(
@@ -526,28 +535,22 @@ def test_simple_import_to_pkg_map():
         'builtin': {},
         'questionable': {
             'stdlib_list': {'stdlib-list'},
-            'IPython.core.inputsplitter': {'ipython', 'autovizwidget'},
+            'IPython.core.inputsplitter': {'ipython', 'jupyter-sphinx'},
             'conda_forge_metadata.autotick_bot': {'conda-forge-metadata'},
-            'conda_forge_metadata.libcfgraph': {'conda-forge-metadata'},
+            'conda_forge_metadata.conda_forge_bot': {'conda-forge-metadata'},
         },
         'questionable no match': {},
         'required': {
             'requests': {
-                'apache-libcloud',
                 'arm_pyart',
-                'autovizwidget',
-                'dbxfs',
-                'google-api-core',
                 'google-cloud-bigquery-storage-core',
+                'jupyter-sphinx',
                 'requests'
             },
             'requests.exceptions': {
-                'apache-libcloud',
                 'arm_pyart',
-                'autovizwidget',
-                'dbxfs',
-                'google-api-core',
                 'google-cloud-bigquery-storage-core',
+                'jupyter-sphinx',
                 'requests'
             },
             'yaml': {'google-cloud-bigquery-storage-core', 'pyyaml', 'rosco'}

--- a/test.py
+++ b/test.py
@@ -459,9 +459,9 @@ def test_get_top_level_import():
         assert top_level_name == ns
 
     ns = ["my_custom_ns.ns"]
-    name = ns[0] + '.something'
+    name = ns[0] + '.blah.something'
     top_level_name = inspection.get_top_level_import_name(name, custom_namespaces=ns)
-    assert top_level_name == ns[0]
+    assert top_level_name == ns[0] + ".blah"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR allows depfinder to use the new import location for bot metadata.